### PR TITLE
Add JuMP v1.8 section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## JuMP v1.8 update
+
+JuMP v1.8.0 added native support for multiobjective problems, so there is no longer
+a need to use the `MultiJuMP.jl` extension. See the JuMP documentation for more
+details: https://jump.dev/JuMP.jl/v1.8/tutorials/linear/multi_objective_knapsack/
+
+A collection of solution algorithms is available in the MultiObjectiveAlgorithms.jl
+package: https://github.com/jump-dev/MultiObjectiveAlgorithms.jl. Please open an issue
+there if you have feature requests or bug reports.
+
 # MultiJuMP
 
 [![Build Status](https://travis-ci.org/anriseth/MultiJuMP.jl.svg?branch=master)](https://travis-ci.org/anriseth/MultiJuMP.jl)


### PR DESCRIPTION
Big news for multi-objective optimization in JuMP: JuMP v1.8 now has native support for multi-objective optimization.

Hopefully, this should mean that all users of this package can switch to pure-JuMP (although we're currently missing a normal boundary intersection method and the nice plotting recipes).

See the documentation for details: https://jump.dev/JuMP.jl/v1.8/tutorials/linear/multi_objective_knapsack/ 